### PR TITLE
Update dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,9 +1,9 @@
 asterism==0.9.0
 ArchivesSnake==0.9.1
-Django==4.0.5
-django-cors-headers==3.12.0
+Django==4.0.6
+django-cors-headers==3.13.0
 django-mptt==0.13.4
 djangorestframework==3.13.1
 psycopg2-binary==2.9.3
 uritemplate==4.1.1
-vcrpy==4.1.1
+vcrpy==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,18 +16,18 @@ bagit==1.8.1
     # via asterism
 boltons==21.0.0
     # via archivessnake
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
-django==4.0.5
+django==4.0.6
     # via
     #   -r requirements.in
     #   asterism
     #   django-cors-headers
     #   django-js-asset
     #   djangorestframework
-django-cors-headers==3.12.0
+django-cors-headers==3.13.0
     # via -r requirements.in
 django-js-asset==2.0.0
     # via django-mptt
@@ -41,7 +41,7 @@ idna==3.3
     # via
     #   requests
     #   yarl
-jarowinkler==1.0.2
+jarowinkler==1.1.0
     # via rapidfuzz
 more-itertools==8.13.0
     # via archivessnake
@@ -59,9 +59,9 @@ pyyaml==6.0
     # via
     #   archivessnake
     #   vcrpy
-rapidfuzz==2.0.11
+rapidfuzz==2.1.2
     # via archivessnake
-requests==2.28.0
+requests==2.28.1
     # via archivessnake
 six==1.16.0
     # via
@@ -73,9 +73,9 @@ structlog==21.5.0
     # via archivessnake
 uritemplate==4.1.1
     # via -r requirements.in
-urllib3==1.26.9
+urllib3==1.26.10
     # via requests
-vcrpy==4.1.1
+vcrpy==4.2.0
     # via -r requirements.in
 wrapt==1.14.1
     # via vcrpy


### PR DESCRIPTION
Bump Django from 4.0.5 to 4.0.6
Bump django-cors-headers from 3.12.0 to 3.13.0
Bump vcrpy from 4.1.1 to 4.2.0